### PR TITLE
Fix erroneous color scheming in StackedBarChart Dynamic Example

### DIFF
--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
@@ -117,10 +117,10 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
       dynamicData: {
         chartTitle: 'Stacked Bar chart',
         chartData: [
-          { legend: 'first', data: this._randomY() },
-          { legend: 'second', data: this._randomY() },
-          { legend: 'third', data: this._randomY() },
-          { legend: 'fourth', data: this._randomY() },
+          { legend: 'first', data: this._randomY(), color: prevState.dynamicData.chartData![0].color },
+          { legend: 'second', data: this._randomY(), color: prevState.dynamicData.chartData![1].color },
+          { legend: 'third', data: this._randomY(), color: prevState.dynamicData.chartData![2].color },
+          { legend: 'fourth', data: this._randomY(), color: prevState.dynamicData.chartData![3].color },
         ],
       },
       statusKey: prevState.statusKey + 1,
@@ -133,10 +133,10 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
       dynamicData: {
         chartTitle: 'Stacked Bar chart',
         chartData: [
-          { legend: 'first', data: 40, color: this._randomColor(0) },
-          { legend: 'second', data: 23, color: this._randomColor(1) },
-          { legend: 'third', data: 35, color: this._randomColor(2) },
-          { legend: 'fourth', data: 87, color: this._randomColor(3) },
+          { legend: 'first', data: prevState.dynamicData.chartData![0].data, color: this._randomColor(0) },
+          { legend: 'second', data: prevState.dynamicData.chartData![1].data, color: this._randomColor(1) },
+          { legend: 'third', data: prevState.dynamicData.chartData![2].data, color: this._randomColor(2) },
+          { legend: 'fourth', data: prevState.dynamicData.chartData![3].data, color: this._randomColor(3) },
         ],
       },
       statusKey: prevState.statusKey + 1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

On clicking 'Change Data' button in StackedBarChart Dynamic Example, the data was randomizing, but so were the colors. 
This was due to the fact of updating the chartData but not unpacking the prevState chartData items which caused data to be passed on without color. So, StackedBarChart just kept assigning random colors .

## New Behavior

The 'Change Data' function has been fixed. All unchanged data items are passed along with changes.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30672
